### PR TITLE
Add no_ssl_verify source option

### DIFF
--- a/assets/lib/common.rb
+++ b/assets/lib/common.rb
@@ -94,7 +94,7 @@ def json!(payload)
 end
 
 Octokit.auto_paginate = true
-Octokit.connection_options[:ssl] = { verify: false } if ENV['http_proxy']
+Octokit.connection_options[:ssl] = { verify: false } if input['source']['no_ssl_verify']
 Octokit.configure do |c|
   c.access_token = input['source']['access_token']
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ end
 
 def check(payload)
   path = ['./assets/check', '/opt/resource/check'].find { |p| File.exist? p }
+  payload[:source][:no_ssl_verify] = true
 
   output = `echo '#{JSON.generate(payload)}' | env http_proxy=#{proxy.url} #{path}`
   JSON.parse(output)
@@ -25,6 +26,7 @@ end
 
 def get(payload = {})
   path = ['./assets/in', '/opt/resource/in'].find { |p| File.exist? p }
+  payload[:source][:no_ssl_verify] = true
 
   output = `echo '#{JSON.generate(payload)}' | env http_proxy=#{proxy.url} #{path} #{dest_dir}`
   JSON.parse(output)
@@ -32,7 +34,7 @@ end
 
 def put(payload = {})
   path = ['./assets/out', '/opt/resource/out'].find { |p| File.exist? p }
-  payload[:source] = { repo: 'jtarchie/test' }
+  payload[:source] = { repo: 'jtarchie/test', no_ssl_verify: true }
 
   output, error, = with_resource do |dir|
     Open3.capture3("echo '#{JSON.generate(payload)}' | env http_proxy=#{proxy.url} #{path} #{dir}")


### PR DESCRIPTION
This adds an optional source configuration to disable ssl verification.
This way ssl verification is not disabled anymore when an http_proxy is set.
This can also be a useful option for endusers when targeting github enterprise instances.