### PR TITLE
More error checking

### DIFF
--- a/assets/lib/in.rb
+++ b/assets/lib/in.rb
@@ -19,6 +19,9 @@ pr = Octokit.pull_request(input['source']['repo'], input['version']['pr'])
 id = pr['number']
 
 system("git clone --depth 1 #{uri} #{destination} 1>&2")
+
+fail 'git clone failed' unless $?.exitstatus == 0
+
 Dir.chdir(destination) do
   system("git submodule update --init --recursive 1>&2")
   system("git fetch -q origin pull/#{id}/head:pr-#{id} 1>&2")

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -17,6 +17,8 @@ id = Dir.chdir(path) do
   `git config --get pullrequest.id`.chomp
 end
 
+fail 'could not get pullrequest `id` from repository' unless id
+
 repo = Repository.new(name: input['source']['repo'])
 pr   = repo.pull_request(id: id)
 


### PR DESCRIPTION
Currently the `in` command doesn't check for errors. A failed clone causes the `get` resource to create (and cache) an empty `input` and gives barely traceable errors down the line (eg: putting a `pending` status will 404 because there is no pullrequest `id` found in the `input`).