### PR TITLE
Allow for configurable contexts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Set the status message for `concourseci` context on specified pull request.
 
 * `status`: *Required.* The status of success, failure, error, or pending.
 
+* `context`: *Optional.* The context on the specified pull request (defaults to `concourseci`)
+
 ## Example pipeline
 
 This is what I am currently using to test this resource on Concourse.

--- a/assets/lib/common.rb
+++ b/assets/lib/common.rb
@@ -19,13 +19,14 @@ class PullRequest
     { ref: sha, pr: id.to_s }
   end
 
-  def status!(state:, atc_url: nil)
+  def status!(state:, atc_url: nil, context: 'concourseci')
+    context ||= 'concourseci'  # Explicit nil (if undefined in hash, for example) should preserve default
     target_url = ("#{atc_url}/builds/#{ENV['BUILD_ID']}" if atc_url)
     Octokit.create_status(
       @repo.name,
       sha,
       state,
-      context: 'concourseci',
+      context: context,
       description: "Concourse CI build #{state}",
       target_url: target_url
     )

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -20,7 +20,9 @@ end
 repo = Repository.new(name: input['source']['repo'])
 pr   = repo.pull_request(id: id)
 
-pr.status!(state: input['params']['status'], atc_url: input['source']['base_url'])
+pr.status!(state: input['params']['status'],
+           atc_url: input['source']['base_url'],
+           context: input['source']['context'])
 
 json!(version: pr.as_json,
       metadata: [


### PR DESCRIPTION
This allows an `out` step to update arbitrary statuses, rather than only `concourseci`.