### PR TITLE
Get target_url base from new environment variable

### DIFF
--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -28,9 +28,11 @@ else
   version = { pr: id, ref: sha }
 end
 
+atc_url = input['source']['base_url'] || ENV['ATC_EXTERNAL_URL']
+
 Status.new(
   state: input['params']['status'],
-  atc_url: input['source']['base_url'],
+  atc_url: atc_url,
   sha: sha,
   repo: repo
 ).create!

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -30,7 +30,7 @@ end
 
 Status.new(
   state: input['params']['status'],
-  atc_url: input['params']['base_url'],
+  atc_url: input['source']['base_url'],
   sha: sha,
   repo: repo
 ).create!


### PR DESCRIPTION
A new environment variable has been added, making the need to specify base url optional: https://github.com/concourse/atc/blob/52e8522186cce3c22503027453839ef4588fbda3/engine/step_metadata.go#L30

Also base_url was retrieved from params instead of source like documented.

Wanted to add a test but could find an easy way to do it using puffing-billy.