### PR TITLE
Support no_proxy environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update \
   openssh-client \
   ruby-json \
   ca-certificates
-RUN gem install octokit --no-rdoc --no-ri
+RUN gem install octokit httpclient --no-rdoc --no-ri
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 
 gem 'octokit'
+gem 'httpclient'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     http_parser.rb (0.6.0)
+    httpclient (2.8.0)
     method_source (0.8.2)
     multi_json (1.11.2)
     multipart-post (2.0.0)
@@ -73,6 +74,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  httpclient
   octokit
   pry
   puffing-billy

--- a/assets/lib/check.rb
+++ b/assets/lib/check.rb
@@ -3,8 +3,8 @@
 
 require 'rubygems'
 require 'json'
-require 'octokit'
 require_relative 'common'
+require 'octokit'
 
 repo = Repository.new(name: input['source']['repo'])
 

--- a/assets/lib/common.rb
+++ b/assets/lib/common.rb
@@ -1,4 +1,10 @@
 # encoding: utf-8
+
+require 'faraday'
+# httpclient and excon are the only Faraday adpater which support
+# the no_proxy environment variable atm
+::Faraday.default_adapter= :httpclient
+
 require 'octokit'
 require 'fileutils'
 

--- a/assets/lib/in.rb
+++ b/assets/lib/in.rb
@@ -5,9 +5,9 @@ destination = ARGV.shift
 
 require 'rubygems'
 require 'json'
+require_relative 'common'
 require 'octokit'
 require 'English'
-require_relative 'common'
 
 def uri
   input['source']['uri'] || "https://github.com/#{input['source']['repo']}"

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -5,8 +5,8 @@ destination = ARGV.shift
 
 require 'rubygems'
 require 'json'
-require 'octokit'
 require_relative 'common'
+require 'octokit'
 
 raise %(`status` "#{input['params']['status']}" is not supported -- only success, failure, error, or pending) unless %w(success failure error pending).include?(input['params']['status'])
 raise '`path` required in `params`' unless input['params'].key?('path')


### PR DESCRIPTION
Since concourse version 1.1 proxy variables  `http_proxy`,`https_proxy` and `no_proxy` are injected in all containers. This is awesome when working behind a proxy against github.com.
But we are also using an internal github enterprise instance where this resource now fails because it does not consider the `no_proxy` environment variable.

octokit uses faraday for making http_request.
There is a long standing issue in faraday to add proper support for the no_proxy environment variable (https://github.com/lostisland/faraday/pull/247). Unfortuantely it seems like this issue is going nowhere.
A workaround is suggested in this issue: https://github.com/berkshelf/berkshelf/issues/1341

The httpclient (and excon) farady adapter picks up proxy settings from the environment automatically.