### PR TITLE
Add ref to git config

### DIFF
--- a/assets/lib/in.rb
+++ b/assets/lib/in.rb
@@ -32,6 +32,7 @@ Dir.chdir(destination) do
   system("git config --add pullrequest.url #{pr['html_url']} 1>&2")
   system("git config --add pullrequest.id #{pr['number']} 1>&2")
   system("git config --add pullrequest.branch #{branch_ref} 1>&2")
+  system("git config --add pullrequest.ref #{ref} 1>&2")
 end
 
 puts JSON.generate(version:  { ref: ref, pr: id.to_s },


### PR DESCRIPTION
Give the ability  to pass  the githash to be used during build or whatever...

What I am not sure if ref will do another call to github.