### PR TITLE
post a comment when the 'comment' param exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Set the status message for `concourse-ci` context on specified pull request.
   (defaults to `status`). Any context will be prepended with `concourse-ci`, so
   a context of `unit-tests` will appear as `concourse-ci/unit-tests` on Github.
 
+* `comment`: *Optional.* The file path of the comment message. Comment owner is same with the owner of `access_token`.
+
 ## Example pipeline
 
 This is what I am currently using to test this resource on Concourse.

--- a/assets/lib/out.rb
+++ b/assets/lib/out.rb
@@ -37,4 +37,12 @@ Status.new(
   context: context
 ).create!
 
+if input['params']['comment']
+  comment_path = File.join(destination, input['params']['comment'])
+  raise %(`path` "#{input['params']['comment']}" does not exist) unless File.exist?(comment_path)
+
+  comment = File.read(comment_path, encoding: Encoding::UTF_8)
+  Octokit.add_comment(input['source']['repo'], id, comment)
+end
+
 json!(version: version, metadata: metadata)

--- a/spec/integration/out_spec.rb
+++ b/spec/integration/out_spec.rb
@@ -70,6 +70,23 @@ describe 'out' do
                              ])
       end
 
+      it 'set into success mode with posting a comment' do
+        File.open(File.join(dest_dir, 'comment'), 'w+') do |f|
+          f.write('message')
+        end
+        proxy.stub("https://api.github.com:443/repos/jtarchie/test/statuses/#{@sha}", method: :post)
+        proxy.stub("https://api.github.com:443/repos/jtarchie/test/issues/1/comments", method: :post)
+             .and_return(json: { id: 1 })
+
+        output, error = put(params: { status: 'success', path: 'resource', comment: 'resource/comment' }, source: { repo: 'jtarchie/test' })
+        expect(output).to eq('version'  => { 'ref' => @sha, 'pr' => '1' },
+                             'metadata' => [
+                               { 'name' => 'status', 'value' => 'success' },
+                               { 'name' => 'url', 'value' => 'http://example.com' }
+                             ])
+      end
+
+
       context 'with bad params' do
         it 'raises an error when path is missing' do
           _, error = put(params: { status: 'pending' }, source: { repo: 'jtarchie/test' })


### PR DESCRIPTION
Like other CI tools, posting a comment into the pull request.
![2016-07-25 16 14 46](https://cloud.githubusercontent.com/assets/856469/17093227/f2c06a7a-5282-11e6-9cf7-be0c1c919801.png)


- new param is added: `comment` which is the file path of the comment message.
  - if this param is passed, try to post a comment with file content.
- this comment is posted by the user who owns the `access_token`.

