### PR TITLE
Can retrieve PRs from a specified base branch

### DIFF
--- a/assets/lib/check.rb
+++ b/assets/lib/check.rb
@@ -11,7 +11,11 @@ input['version'] ||= {}
 if input['source']['every']
   json!(repo.pull_requests.map(&:as_json))
 else
-  next_pull_request = repo.next_pull_request(id: input['version']['pr'], sha: input['version']['ref'])
+  next_pull_request = repo.next_pull_request(
+    id: input['version']['pr'],
+    sha: input['version']['ref'],
+    base: input['source']['base']
+  )
   if next_pull_request
     json!([next_pull_request.as_json])
   else

--- a/assets/lib/common.rb
+++ b/assets/lib/common.rb
@@ -79,8 +79,8 @@ class Repository
     @name = name
   end
 
-  def pull_requests
-    @pull_requests ||= Octokit.pulls(name, state: 'open', sort: 'updated', direction: 'desc').map do |pr|
+  def pull_requests(args = {})
+    @pull_requests ||= Octokit.pulls(name, pulls_options(args)).map do |pr|
       PullRequest.new(repo: self, pr: pr)
     end
   end
@@ -90,8 +90,8 @@ class Repository
     PullRequest.new(repo: self, pr: pr)
   end
 
-  def next_pull_request(id: nil, sha: nil)
-    return if pull_requests.empty?
+  def next_pull_request(id: nil, sha: nil, base: nil)
+    return if pull_requests(base: base).empty?
 
     if id && sha
       current = pull_requests.find { |pr| pr.equals?(id: id, sha: sha) }
@@ -101,6 +101,16 @@ class Repository
     pull_requests.find do |pr|
       pr != current && pr.ready?
     end
+  end
+
+  private
+
+  def pulls_options(base: nil)
+    base ? default_opts.merge(base: base) : default_opts
+  end
+
+  def default_opts
+    { state: 'open', sort: 'updated', direction: 'desc' }
   end
 end
 

--- a/spec/integration/check_spec.rb
+++ b/spec/integration/check_spec.rb
@@ -19,6 +19,19 @@ describe 'check' do
     end
   end
 
+  context 'when targetting a base branch other than master' do
+    must_stub_query_params
+
+    before do
+      proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls?base=my-base-branch&direction=desc&per_page=100&sort=updated&state=open')
+           .and_return(json: [{ number: 1, head: { sha: 'abcdef' } }])
+    end
+
+    it 'retrieves pull requests for the specified base branch' do
+      expect(check(source: { repo: 'jtarchie/test', base: 'my-base-branch' })).to eq [{ 'ref' => 'abcdef', 'pr' => '1' }]
+    end
+  end
+
   context 'with check for `version: every`' do
     context 'when there are no pull requests' do
       before do
@@ -43,8 +56,10 @@ describe 'check' do
     end
 
     context 'when there is an open pull request' do
+      must_stub_query_params
+
       before do
-        proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls')
+        proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls?direction=desc&per_page=100&sort=updated&state=open')
              .and_return(json: [{ number: 1, head: { sha: 'abcdef' } }])
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,3 +71,12 @@ def with_resource
   FileUtils.cp_r(dest_dir, File.join(tmp_dir, 'resource'))
   yield(tmp_dir)
 end
+
+def must_stub_query_params
+  around do |example|
+    old_strip_params = Billy.config.strip_query_params
+    Billy.config.strip_query_params = false
+    example.run
+    Billy.config.strip_query_params = old_strip_params
+  end
+end


### PR DESCRIPTION
This adds a `base: mybranchname` option to `source`. The GitHub API is then called with `base=mybranchname` when retrieving new versions.

Modify existing test to assert on params, to ensure we don't
unnecessarily request an empty base when default base is desired.

I've tested this on https://ci.rabbitmq.com/. For reference, it was the `rabbitmq_trust_store_pr` resource.

* Configured `base: master` on a PR resource using `camelpunch/pr`.
* Opened a PR against the `master` branch.
* Opened a PR against the `stable` branch.

Only the `master` branch PR tests were run, which was as expected.