### PR TITLE
Added basebranch git config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ There is `git config` information set on the repo about the PR, which can be con
 For example:
 
 ```bash
-git config --get pullrequest.url    # returns the URL to the pull request
-git config --get pullrequest.branch # returns the branch name used for the pull request
-git config --get pullrequest.id     # returns the ID number of the PR
+git config --get pullrequest.url        # returns the URL to the pull request
+git config --get pullrequest.branch     # returns the branch name used for the pull request
+git config --get pullrequest.id         # returns the ID number of the PR
+git config --get pullrequest.basebranch # returns the base branch used for the pull request
 ```
 
 #### Parameters

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -36,6 +36,7 @@ module Commands
           git config --add pullrequest.url #{pr['html_url']} 1>&2
           git config --add pullrequest.id #{pr['number']} 1>&2
           git config --add pullrequest.branch #{pr['head']['ref']} 1>&2
+          git config --add pullrequest.basebranch #{pr['base']['ref']} 1>&2
         BASH
       end
 

--- a/spec/commands/in_spec.rb
+++ b/spec/commands/in_spec.rb
@@ -52,7 +52,7 @@ describe Commands::In do
       end
 
       before(:all) do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
         @output = get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' })
       end
 
@@ -82,11 +82,17 @@ describe Commands::In do
         value = git('config pullrequest.branch', dest_dir)
         expect(value).to eq 'foo'
       end
+
+      it 'sets config variable to base_branch name' do
+        value = git('config pullrequest.basebranch', dest_dir)
+        expect(value).to eq 'master'
+      end
+
     end
 
     context 'when the git clone fails' do
       it 'provides a helpful erorr message' do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => 'invalid_git_uri', 'repo' => 'jtarchie/test' })
@@ -96,7 +102,7 @@ describe Commands::In do
 
     context 'when `every` is not defined' do
       it 'skips the deprecation warning' do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' })
@@ -106,7 +112,7 @@ describe Commands::In do
 
     context 'when `every` is defined' do
       it 'shows a deprecation warning' do
-        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' })
+        stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1', html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' })
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test', 'every' => true })
@@ -119,17 +125,17 @@ describe Commands::In do
     context 'and fetch_merge is false' do
       it 'checks out as a branch named in the PR' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
 
-        value = git('rev-parse --abbrev-ref HEAD', dest_dir)
+            value = git('rev-parse --abbrev-ref HEAD', dest_dir)
         expect(value).to eq 'pr-foo'
       end
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => false })
@@ -140,7 +146,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'checks out the branch the PR would be merged into' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
 
         get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params:' => { 'fetch_merge' => true })
 
@@ -150,7 +156,7 @@ describe Commands::In do
 
       it 'does not fail cloning' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, mergeable: true)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: true)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })
@@ -163,7 +169,7 @@ describe Commands::In do
     context 'and fetch_merge is true' do
       it 'raises a helpful error message' do
         stub_json('https://api.github.com:443/repos/jtarchie/test/pulls/1',
-                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, mergeable: false)
+                  html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' }, mergeable: false)
 
         expect do
           get('version' => { 'ref' => @ref, 'pr' => '1' }, 'source' => { 'uri' => git_uri, 'repo' => 'jtarchie/test' }, 'params' => { 'fetch_merge' => true })

--- a/spec/integration/in_spec.rb
+++ b/spec/integration/in_spec.rb
@@ -35,7 +35,7 @@ describe 'get' do
   context 'for every PR that is checked out' do
     before do
       proxy.stub('https://api.github.com:443/repos/jtarchie/test/pulls/1')
-           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' } })
+           .and_return(json: { html_url: 'http://example.com', number: 1, head: { ref: 'foo' }, base: { ref: 'master' } })
     end
 
     it 'checks out the pull request to dest_dir' do


### PR DESCRIPTION
All of the mock api / stub_json parameter had to be adjusted to reflect the new `base: ref: key` response. This is because the tests run in tmpdirs which set the git config parameters each time using the common in.rb/output function, and if we don't set them for each of the tests this function will fail.