### PR TITLE
Fix support of no_proxy

### DIFF
--- a/assets/lib/commands/base.rb
+++ b/assets/lib/commands/base.rb
@@ -1,10 +1,12 @@
 require 'faraday'
+# httpclient and excon are the only Faraday adpater which support
+# the no_proxy environment variable atm
+# NOTE: this has to be set before require octokit
+::Faraday.default_adapter = :httpclient
+
 require 'octokit'
 require_relative '../input'
 
-# httpclient and excon are the only Faraday adpater which support
-# the no_proxy environment variable atm
-::Faraday.default_adapter = :httpclient
 
 module Commands
   class Base

--- a/assets/lib/commands/in.rb
+++ b/assets/lib/commands/in.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'octokit'
 require 'English'
 require 'json'
 require_relative 'base'

--- a/assets/lib/commands/out.rb
+++ b/assets/lib/commands/out.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'json'
-require 'octokit'
 require_relative 'base'
 require_relative '../repository'
 require_relative '../status'


### PR DESCRIPTION
Somewhere along the lines the changes merged by #14 broke.
The default_client needs to be set before octokit is required.