### PR TITLE
filter: add a new filter for organization membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ marked with that specific label. It is case insensitive.
 * `git_config`: *Optional*. If specified as (list of pairs `name` and `value`)
   it will configure git global options, setting each name with each value.
 
+* `org`: *Optional*. If set to a string it will only return pull requests where
+the owner is part of an organization. It is case sensitive.
+
   This can be useful to set options like `credential.helper` or similar.
 
   See the [`git-config(1)` manual page](https://www.kernel.org/pub/software/scm/git/docs/git-config.html)

--- a/assets/lib/filters/org.rb
+++ b/assets/lib/filters/org.rb
@@ -1,0 +1,18 @@
+module Filters
+  class Org
+    def initialize(pull_requests:, input: Input.instance)
+      @pull_requests = pull_requests
+      @input = input
+    end
+
+    def pull_requests
+      if @input.source.org
+        @memoized ||= @pull_requests.select do |pr|
+          Octokit.organization_member?(@input.source.org, pr.user[:login])
+        end
+      else
+        @pull_requests
+      end
+    end
+  end
+end

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -6,7 +6,7 @@ require_relative 'filters/path'
 class Repository
   attr_reader :name
 
-  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label])
+  def initialize(name:, input: Input.instance, filters: [Filters::All, Filters::Path, Filters::Fork, Filters::Label, Filters::Org])
     @filters = filters
     @name    = name
     @input   = input


### PR DESCRIPTION
in some cases you want to restrict a CI run only for trusted
organization members

Signed-off-by: Maximilian Meister <mmeister@suse.de>