### PR TITLE
Prevent `check` from missing versions

### DIFF
--- a/assets/lib/filters/all.rb
+++ b/assets/lib/filters/all.rb
@@ -8,8 +8,19 @@ module Filters
     end
 
     def pull_requests
-      @pull_requests ||= Octokit.pulls(input.source.repo, pull_options).map do |pr|
-        PullRequest.new(pr: pr)
+      if input.version.pr.nil?
+        @pull_requests ||= Octokit.pulls(input.source.repo, pull_options).map {
+          |pr| PullRequest.new(pr: pr)
+        }
+      else
+        pr = Octokit.pull_request(input.source.repo, input.version.pr)
+        pr.head.sha = input.version.ref
+        last_pr = PullRequest.new(pr: pr)
+        @pull_requests ||= Octokit.pulls(input.source.repo, pull_options).map {
+          |pr| PullRequest.new(pr: pr)
+        }.reject {
+          |pr| pr.id == last_pr.id and pr.sha == last_pr.sha
+        }.unshift(last_pr)
       end
     end
 


### PR DESCRIPTION
There are situations where new versions of the PR resource will can get
lost. This happens because the versions that are returned are sorted by
when they were last updated. Comments on PRs can affect the update time.
This means that between checks, if the version Concourse passes to the
`check` script is commented on, Concourse will only consider anything
updated after this PR a valid version. This change puts the version
Concourse passes to the `check` script at the start of the list of
versions it returns. This ensures that a valid version does not get
skipped.